### PR TITLE
Incorrect capacity when dragging an item back and forth between connected fsortables

### DIFF
--- a/src/jquery-fsortable.js
+++ b/src/jquery-fsortable.js
@@ -249,8 +249,10 @@ $.widget("ntx.fsortable", $.ui.sortable, {
 			ui.sender.sortable("refresh");
 
 			// Update capacities.
-			inst._capacity++;
-			inst._occupied--;
+			if (!inst._connected) {
+				inst._capacity++;
+				inst._occupied--;
+			}
 
 			// Prepare the sender in case the item returns to them.
 			inst._outside = true;

--- a/tests/test_connected.js
+++ b/tests/test_connected.js
@@ -73,3 +73,27 @@ test("test_over_connected_then_back", function() {
 	testfsortable("#fsortable2", [1, null, null, null, 2]);
 });
 
+test("test_stress_drag_connected", function() {
+	var from = "#fsortable2 .item:first",
+			to = "#fsortable .fsortable-empty:first";
+
+	var fromOffset = findCenter($(from)),
+			toOffset = findCenter($(to)),
+			toOffset_back = toOffset;
+
+	var steps = 20;
+
+	$(from).simulate("mousedown", fromOffset);
+	$(document).simulate("mousemove", toOffset);
+
+	for (var i = 0; i < steps; i++) {
+		$(document).simulate("mousemove", fromOffset);
+		$(document).simulate("mousemove", toOffset);
+	}
+
+	$(from).simulate("mouseup", toOffset);
+	$(from).simulate("click", toOffset);
+	testfsortable("#fsortable", [1, null, null, null, null]);
+	testfsortable("#fsortable2", [null, null, null, null, 2]);
+});
+

--- a/tests/test_connected.js
+++ b/tests/test_connected.js
@@ -78,8 +78,7 @@ test("test_stress_drag_connected", function() {
 			to = "#fsortable .fsortable-empty:first";
 
 	var fromOffset = findCenter($(from)),
-			toOffset = findCenter($(to)),
-			toOffset_back = toOffset;
+			toOffset = findCenter($(to));
 
 	var steps = 20;
 


### PR DESCRIPTION
### Need

``` gherkin
Given I have 2 connected fsortables
And the first one has size 5 and capacity 5
And the second one has size 3 and capacity 2
When I drag the item from the second fsortable to the first one
And then I drag it back to the second fsortable
And then I drag it back to the first fsortable
And then I drag it back to the second fsortable
And I drop it
Then the first fsortable should have capacity 5
And the second fsortable should have capacity 2
```
### Actual

The second fsortable will have capacity 3
### Prerequisites
- inspect the event flow in this case
- [line 252](https://github.com/NiGhTTraX/jquery-fsortable/blob/master/src/jquery-fsortable.js#L252)
### Solution

Fix how we handle items coming back to us after they were dragged to a connected sortable.
### TODO
- [x] fix updating capacities
- [x] write tests
