### PR TITLE
Draggable helper z-index stacking context

### DIFF
--- a/javascripts/demo.js
+++ b/javascripts/demo.js
@@ -2,7 +2,9 @@ $(document).ready(function() {
 	$(".fs").fsortable({
 		connectWith: ".fs:not(.full)",
 		tolerance: "pointer",
-		size: 5
+		size: 5,
+		helper: "clone",
+		appendTo: "body",
 	}).disableSelection();
 
 	$("#content .item").draggable({


### PR DESCRIPTION
When dragging an item between connected fsortables the dragging helper will be underneath the items of the destination fsortable.
## Need

``` gherkin
As a potential user
When I check out the demo
I want to be impressed.
```
## Deliverables

``` gherkin
As a user
Given that I am on the demo page
When I drag an item between connected fsortables
Then the draggable helper will be on top.
```
## Solution

Move the helper DOM element to the end of the `body` to resolve z-index stacking issues.
#### Prerequisites
- http://api.jqueryui.com/draggable/#option-helper
- http://api.jqueryui.com/draggable/#option-appendTo
- [The stacking context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context)
#### TODO
- [x] change the `appendTo` option.
